### PR TITLE
chore: use NODE_TYPE input in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
       REPOSITORY:
         required: true
         type: string
+      NODE_TYPE:
+        required: false
+        type: string
+        default: 'compute'
 
 jobs:
   build-push:
@@ -47,9 +51,11 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: .
+        build-args: ${{ inputs.NODE_TYPE }}
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ${{ inputs.REGISTRY }}/node:latest
+          ${{ inputs.REGISTRY }}/node:${{ inputs.NODE_TYPE }}
           ${{ inputs.REGISTRY }}/node:${{ github.sha }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Build and push Docker images
       id: build-and-push
-      if: ${{inputs.REPOSITORY != 'Network' }}
+      if: inputs.REPOSITORY != 'Network'
       uses: docker/build-push-action@v3
       with:
         context: .
@@ -47,7 +47,7 @@ jobs:
 
     - name: Build and push A-Block node
       id: build-and-push-node
-      if: ${{inputs.REPOSITORY == 'Network' }}
+      if: inputs.REPOSITORY == 'Network'
       uses: docker/build-push-action@v3
       with:
         context: .


### PR DESCRIPTION
Adds the ability to pass the NODE_TYPE as an input to the workflow and also tags the image with NODE_TYPE, default to 'compute'.